### PR TITLE
cheaphack: create region on xtea send via the rebuild region encoders.

### DIFF
--- a/game/src/main/kotlin/gg/rsmod/game/message/encoder/RebuildNormalEncoder.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/message/encoder/RebuildNormalEncoder.kt
@@ -42,7 +42,7 @@ class RebuildNormalEncoder : MessageEncoder<RebuildNormalMessage>() {
                 for (z in lz..rz) {
                     if (!forceSend || z != 49 && z != 149 && z != 147 && x != 50 && (x != 49 || z != 47)) {
                         val region = z + (x shl 8)
-                        val keys = message.xteaKeyService?.get(region) ?: XteaKeyService.EMPTY_KEYS
+                        val keys = message.xteaKeyService?.getAndCreateRegion(region) ?: XteaKeyService.EMPTY_KEYS
                         for (xteaKey in keys) {
                             buf.writeInt(xteaKey) // Client always reads as int
                         }

--- a/game/src/main/kotlin/gg/rsmod/game/message/encoder/RebuildRegionEncoder.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/message/encoder/RebuildRegionEncoder.kt
@@ -31,7 +31,7 @@ class RebuildRegionEncoder : MessageEncoder<RebuildRegionMessage>() {
                 val rz = copiedCoords shr 3 and 0x7FF
                 val region = rz / 8 + (rx / 8 shl 8)
                 if (regions.add(region)) {
-                    val keys = message.xteaKeyService!!.get(region)
+                    val keys = message.xteaKeyService!!.getAndCreateRegion(region)
                     for (xteaKey in keys) {
                         xteaBuffer.writeInt(xteaKey) // Client always reads as int
                     }

--- a/game/src/main/kotlin/gg/rsmod/game/service/xtea/XteaKeyService.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/service/xtea/XteaKeyService.kt
@@ -55,6 +55,12 @@ class XteaKeyService : Service {
     override fun terminate(server: Server, world: World) {
     }
 
+    //Added method to create the region when xteas are accessed which is through the rebuild region encoders.
+    fun getAndCreateRegion(region: Int): IntArray {
+        w.definitions.createRegion(w, region)
+        return get(region)
+    }
+
     fun get(region: Int): IntArray {
         if (keys[region] == null) {
             logger.trace { "No XTEA keys found for region $region." }
@@ -63,7 +69,15 @@ class XteaKeyService : Service {
         return keys[region]!!
     }
 
+    //Scuffed lateinit shenanigans. Potentially move the w.definitions.createRegion within the xtea message encoders.
+    //Not sure about rsmods threading model or how the message encoding works.
+    //Most likely message encoding is run within the netty threads so is calling create region like this safe?
+    //Is the netty impl multithreaded?
+    private lateinit var w: World;
+
     private fun loadKeys(world: World) {
+        w = world;
+
         /*
          * Get the total amount of valid regions and which keys we are missing.
          */


### PR DESCRIPTION
Added notes about the concerns.

    //Scuffed lateinit shenanigans. Potentially move the w.definitions.createRegion within the xtea message encoders.
    //Not sure about rsmods threading model or how the message encoding works.
    //Most likely message encoding is run within the netty threads so is calling create region like this safe?
    //Is the netty impl multithreaded?

What has been done?
Now the message region encoders trigger region load/mapdata when xtea is sent to the client. 

Has your code been documented?
Yes


TIPS for the future

We can potentially just move this region creation to the player.login where the RebuildLoginMessage is and then also the PreSynchronizationTask where it dispatches the rebuild normal/region methods

Alternative would be moving the world reference within the message encoders to remove the cheaphackery from the xtea service but my network concerns are above.

Most likely best bet is just to add a method to get surrounding regions and load them if nearby and call that within the pre synchnronization task and also the login.
cant pr back to your repo. all g. lmk if you have any other issues but should be good.